### PR TITLE
Debounce searchInput

### DIFF
--- a/src/components/SearchInput.vue
+++ b/src/components/SearchInput.vue
@@ -2,19 +2,40 @@
   <input
     class="form-control"
     type="search"
+    v-model.trim="value"
     :placeholder="placeholder"
-    @keyup="$emit('text', $event.target.value)"
   />
 </template>
 
 <script>
+let timeoutId;
+
 export default {
   name: 'SearchInput',
+  data() {
+    return {
+      value: '',
+    };
+  },
   props: {
     placeholder: {
       type: String,
       required: false,
       default: '',
+    },
+  },
+  watch: {
+    value(newValue) {
+      // TODO: Use request time instead of debounce as it will improve experience
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        this.emitOnDebounce(newValue);
+      }, 500);
+    },
+  },
+  methods: {
+    emitOnDebounce(value) {
+      this.$emit('text', value);
     },
   },
 };

--- a/tests/unit/components/SearchInput.spec.js
+++ b/tests/unit/components/SearchInput.spec.js
@@ -30,12 +30,19 @@ describe('SearchInput', () => {
   });
 
   test('emits input text', () => {
+    jest.useFakeTimers();
+
     const input = wrapper.find('input');
     const inputValue = 'someuser';
 
-    input.element.value = inputValue;
-    input.trigger('keyup');
+    wrapper.vm.value = inputValue;
 
+    jest.runAllTimers();
+
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 500);
+
+    expect(input.element.value).toBe(inputValue);
     expect(wrapper.emitted('text')[0][0]).toBe(inputValue);
   });
 });

--- a/tests/unit/components/SearchListItem.spec.js
+++ b/tests/unit/components/SearchListItem.spec.js
@@ -52,5 +52,4 @@ describe('SearchListItem', () => {
 
     expect(wrapper.emitted('click')[0][0]).toBe(name);
   });
-
 });


### PR DESCRIPTION
- Uses `v-model`  with `watch` instead of `@keyup` event
- Uses debounce to avoid multiple triggers and concurrency requests (order not guaranteed)